### PR TITLE
bs-requirement-change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ PyDictionary==1.5.2
 requests==2.21.0
 wikipedia==1.4.0
 google==2.0.2
-bs4==4.7.1
+beautifulsoup4==4.7.1


### PR DESCRIPTION
# brief description of changes
Installing requirements with bs4 causes error: `Could not find a version that satisfies the requirement bs4==4.7.1`
Changed according to: [https://stackoverflow.com/a/25213365](url)