### PR TITLE
.pydocs plugin

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
- MIT License
+MIT License
 
 Copyright (c) 2018 Abdur-Rahmaan Janhangeer
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+ MIT License
 
 Copyright (c) 2018 Abdur-Rahmaan Janhangeer
 

--- a/honeybot/plugins/pydocs.py
+++ b/honeybot/plugins/pydocs.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""
+[dictionary.py]
+Dictionary Plugin
+
+[Author]
+Milad H, 
+
+[About]
+Searches the python documentatioin(pydocs) for the related keyword(s)
+and returns some of the relevant links
+
+
+[Commands]
+>>> .pydocs <keyword>
+returns links in python documentation related to the keyword
+"""
+
+
+class Plugin:
+    def __init__(self):
+        pass
+
+    def run(self, incoming, methods, info, bot_info):
+        try:
+            msgs = info['args'][1:][0].split()
+
+            if info['command'] == 'PRIVMSG' and msgs[0] == '.dictionary':
+                dict = PyDictionary()
+                word = str(msgs[1])
+                defin = dict.meaning(word)['Noun']
+                for definition in defin:
+                    methods['send'](info['address'], definition)
+        except Exception as e:
+            print('woops plug', e)

--- a/honeybot/settings/AUTOJOIN_CHANNELS.conf
+++ b/honeybot/settings/AUTOJOIN_CHANNELS.conf
@@ -1,1 +1,1 @@
-#ltch
+#bottestingmu


### PR DESCRIPTION
# brief description of changes

I added a new plugin .pydocs user will enter .pydocs "keywords" where "keywords" are the ones that he/she wants to search in python docs. 
The problem now is that when I send the request using "requests" library the response is not same as when you do it with the browser yourself

It returns a page but there are no search results in it. So I was just wondering should we use something like Selenium (because I think its because of the Javascript that they have used) or is there any other solution for this.
