### PR TITLE
Sasl

### DIFF
--- a/honeybot/main.py
+++ b/honeybot/main.py
@@ -7,6 +7,7 @@ import logging
 import socket
 import sys
 import time
+from ldap import sasl
 
 connect_config = configparser.ConfigParser()
 connect_config.read('settings/CONNECT.conf')

--- a/honeybot/main.py
+++ b/honeybot/main.py
@@ -210,7 +210,10 @@ class Bot_core(object):
     BOT IRC FUNCTIONS
     '''
     def connect(self):
-            self.irc.connect((self.server_url, self.port))
+        #check auth methods available --> auth_list
+        #authenticate(auth_method) for auth_method in auth_list
+
+        self.irc.connect((self.server_url, self.port))
 
     def identify(self):
         self.send(self.identify_command())


### PR DESCRIPTION
At current, class Bot_core is unable to authenticate via SASL, which is required if attempting to connect via verizon hot spot. I suggest that we use the python3-ldap package to handle authentication. The package info can be found here: https://www.python-ldap.org/en/latest/reference/ldap-sasl.html 

Of course, we'll need to update the requirements.txt, which I'll do if this idea is good to go.

I imported sasl from ldap as an example and added comments in connect(), line 213 and 214 to show where I believe this adaptation should occur. It may also be better to pass an argument[auth_type] to connect and:
     if auth_type == 'sasl': 
          'authenticate via sasl'
    else:
          self.irc.connect((self.server_url, self.port))
